### PR TITLE
Add CI GH Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master

--- a/ingest/build-configs/ci/config.yaml
+++ b/ingest/build-configs/ci/config.yaml
@@ -1,0 +1,6 @@
+# TODO: If the ingest workflow ever runs too long, we should figure out a way
+# to subset the ingest data. Currently, the CI just runs the default ingest workflow.
+
+# Snakemake requires at least one top level key in a config file, so including
+# a bogus key here that should not be used anywhere in the Snakemake workflow
+bogus_ci_config: "bogus_ci_config"

--- a/phylogenetic/build-configs/ci/config.yaml
+++ b/phylogenetic/build-configs/ci/config.yaml
@@ -1,7 +1,0 @@
-# This configuration file contains the custom configurations parameters
-# for the CI workflow to run with the example data.
-
-# Custom rules to run as part of the CI automated workflow
-# The paths should be relative to the phylogenetic directory.
-custom_rules:
-  - build-configs/ci/copy_example_data.smk


### PR DESCRIPTION
## Description of proposed changes

Add CI GH Action workflow to test the ingest workflow. 
Removes the phylogenetic CI config since the workflow is still WIP and doesn't actually run yet. 

## Related issue(s)

Prompted by #4 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
