### PR TITLE
Add host taxonomic categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # CHANGELOG
+* 20 August 2024: Assign host taxa to taxonomic groupings that are relevant to rabies for coloring in auspice
 * 12 August 2024: Create a full genome phylogeny for rabies [PR#3](https://github.com/nextstrain/rabies/pull/3)
 * 25 July 2024: Add CI GH Action workflow to test the ingest workflow [PR#6](https://github.com/nextstrain/rabies/pull/6)
 * 15 July 2024: Make rabies-specific modifications to the ingest directory (which originated from the pathogen-repo-guide) [PR#2](https://github.com/nextstrain/rabies/pull/2)

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -23,6 +23,7 @@ ncbi_datasets_fields:
   - update-date
   - length
   - host-name
+  - host-tax-id
   - isolate-lineage-source
   - biosample-acc
   - submitter-names

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -54,12 +54,18 @@ curate:
     release-date: date_released
     update-date: date_updated
     length: length
-    host-name: host
+    host-name: host_latin_name
+    host-tax-id: host_tax_id
     isolate-lineage-source: sample_type
     biosample-acc: biosample_accessions
     submitter-names: authors
     submitter-affiliation: institution
     submitter-country: submitter_country
+    Group name: host_group
+    Curator common name: host_common_name
+    Family name: host_family
+    Genus name: host_genus
+
   # Standardized strain name regex
   # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
   strain_regex: "^.+$"
@@ -110,6 +116,11 @@ curate:
     "location",
     "length",
     "host",
+    "host_latin_name",
+    "host_family",
+    "host_genus",
+    "host_group",
+    "host_common_name",
     "date_released",
     "date_updated",
     "sra_accessions",

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -107,6 +107,9 @@ rule curate:
                 --abbr-authors-field {params.abbr_authors_field} \
             | augur curate apply-geolocation-rules \
                 --geolocation-rules {input.all_geolocation_rules} \
+            | scripts/add-host-categories.py \
+            --latin-field host_latin_name --family-field host_family \
+            --genus-field host_genus --group-field host_group  \
             | augur curate apply-record-annotations \
                 --annotations {input.annotations} \
                 --id-field {params.annotations_id} \

--- a/ingest/scripts/add-host-categories.py
+++ b/ingest/scripts/add-host-categories.py
@@ -1,0 +1,70 @@
+#! /usr/bin/env python3
+"""
+From stdin, generates host names using info from the NCBI taxonomy output of the NDJSON record, with output to 'host'
+
+Outputs the modified record to stdout.
+"""
+
+import argparse
+import json
+from sys import stdin, stdout
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate host names and output to 'host'.")
+    parser.add_argument("--latin-field", default='host_latin_name',
+        help="Field from the records to use as the host latin name.")
+    parser.add_argument("--family-field", default='host_family',
+        help="Field from the records to use as the host Family name.")
+    parser.add_argument("--genus-field", default='host_genus',
+        help="Field from the records to use as the host genus name.")
+    parser.add_argument("--group-field", default='host_group',
+        help="Field from the records to use as the host group.")
+    return parser.parse_args()
+
+def _set_host_name_transformed(record, args):
+    latin_replacements = {
+        "Canis lupus familiaris": "Domestic Dog",
+        "Homo sapiens": "Human",
+        "Bos taurus": "Cattle",
+        "Didelphis albiventris": "Other Mammal",
+        "Elephas maximus": "Other Mammal",
+        "Dasypus novemcinctus": "Other Mammal"}
+    family_replacements = {"Mephitidae": "Skunk"}
+    group_replacements = {
+        "odd-toed ungulates": "Other Ungulate",
+        "even-toed ungulates & whales": "Other Ungulate",
+        "carnivores": "Other Carnivore",
+        "bats": "Bat",
+        "birds": "Bird",
+        "primates": "Other Mammal",
+        "rodents": "Other Mammal",
+        "mammals": "Other Mammal"
+    }
+    latin_field = record[args.latin_field]
+    family_field = record[args.family_field]
+    group_field = record[args.group_field]
+
+    if record[args.family_field] == "Canidae" and record[args.genus_field] == "Vulpes":
+        return "Fox (Vulpes sp.)"
+    elif record[args.family_field] == "Procyonidae" and record[args.genus_field] == "Procyon":
+        return "Raccoon"
+    elif latin_field in latin_replacements:
+        return latin_replacements[latin_field]
+    elif family_field in family_replacements:
+        return family_replacements[family_field]
+    elif group_field in group_replacements:
+        return group_replacements[group_field]
+    else:
+        return group_field
+
+def main():
+    args = parse_args()
+
+    for index, record in enumerate(stdin):
+        record = json.loads(record)
+        record['host'] = _set_host_name_transformed(record, args)
+        stdout.write(json.dumps(record) + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -31,6 +31,16 @@
       "key": "host",
       "title": "Host",
       "type": "categorical"
+    },
+    {
+      "key": "host_latin_name",
+      "title": "Host latin name",
+      "type": "categorical"
+    },
+    {
+      "key": "host_common_name",
+      "title": "Host common name",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -49,7 +49,7 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "region"
+    "color_by": "host"
   },
   "filters": [
     "region",

--- a/phylogenetic/defaults/colors.tsv
+++ b/phylogenetic/defaults/colors.tsv
@@ -5,3 +5,16 @@ region	Africa	#8ABB6A
 region	Europe	#BEBB48
 region	South America	#E29E39
 region	North America	#E2562B
+#
+# Host taxa
+host	Bat	#3F47C9
+host	Domestic Dog	#4274CE
+host	Fox (Vulpes sp.)	#4F97BB
+host	Raccoon	#64AC99
+host	Skunk	#7EB976
+host	Other Carnivore	#9EBE5A
+host	Cattle	#BEBB48
+host	Other Ungulate	#D9AE3E
+host	Human	#E69036
+host	Other Mammal	#E35F2D
+host	Bird	#DB2823


### PR DESCRIPTION
## Description of proposed changes

Assigns host taxa to taxonomic groupings that are relevant to rabies for coloring in auspice through the following steps:
* Extract the Host Taxonomic ID numbers from the metadata output by NCBI Datasets
* Obtain detailed taxonomic info for each host taxon by inputting the Host Taxonomic ID numbers into the NCBI Datasets Taxonomy Package using the `datasets download taxonomy` function
* Add the detailed taxonomic info to the metadata
* Use a custom python script to assign host taxa to taxonomic categories that are relevant for rabies

NOTE: Testing this PR requires running the ingest workflow and then copy/pasting the output from `ingest/results` to `phylogenetic/data`. This is because the ingest output that is updated daily on S3 does not include the modifications that are made by the ingest workflow and used in the phylogenetic workflow in this PR.

An example tree generated with these changes can be viewed [here](https://nextstrain.org/staging/rabies/hosttax2)

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
