### PR TITLE
ingest: Filter out empty host "Query"

### DIFF
--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -146,6 +146,7 @@ rule join_metadata_and_hostinfo:
     shell:
         """
         unzip -p {input.ncbi_hosttax_info} ncbi_dataset/data/taxonomy_summary.tsv \
+        | tsv-filter -H --not-blank Query \
         | tsv-select -H -f {params.ncbi_hosttax_columns} \
         | tsv-join -H \
         --filter-file - \


### PR DESCRIPTION
Since we need to join the host taxonomy info with the metadata via the "Query" key, filter out lines where the "Query" column is empty.

This is also a work-around that resolves <https://github.com/nextstrain/rabies/issues/17>.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
