### PR TITLE
Plot French Guiana samples by geography

### DIFF
--- a/ingest/defaults/geolocation_rules.tsv
+++ b/ingest/defaults/geolocation_rules.tsv
@@ -4,3 +4,6 @@
 # If creating a general rule, then the raw field value can be substituted with '*'
 # Lines starting with '#' will be ignored as comments.
 # Trailing '#' will be ignored as comments.
+Europe/France/French Guiana/*	South America/French Guiana (France)/French Guiana (France)/*
+Europe/France/France Guiana/*	South America/French Guiana (France)/French Guiana (France)/*
+South America/French Guiana/*/*	South America/French Guiana (France)/*/*

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -3,6 +3,7 @@ files:
     exclude: "defaults/dropped_strains.txt"
     reference: "defaults/rabies_reference.gb"
     colors: "defaults/colors.tsv"
+    lat_longs: "defaults/lat_longs.tsv"
     auspice_config: "defaults/auspice_config.json"
     description: "defaults/description.md"
 filter:

--- a/phylogenetic/defaults/lat_longs.tsv
+++ b/phylogenetic/defaults/lat_longs.tsv
@@ -1,0 +1,1 @@
+country	French Guiana (France)	4.0039882	-52.999998

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -15,6 +15,7 @@ rule export:
         aa_muts = "results/aa_muts.json",
         year = "results/year.json",
         colors = config["files"]["colors"],
+        lat_longs = config["files"]["lat_longs"],
         auspice_config = config["files"]["auspice_config"],
         description = config["files"]["description"]
     output:
@@ -33,6 +34,7 @@ rule export:
             --metadata-id-columns {params.strain_id} \
             --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.year} \
             --colors {input.colors} \
+            --lat-longs {input.lat_longs} \
             --auspice-config {input.auspice_config} \
             --include-root-sequence-inline \
             --output {output.auspice_json} \


### PR DESCRIPTION
## Description of proposed changes
This PR makes samples that were collected in French Guiana plot on the map within French Guiana, rather than Europe, through the following:
* Adding new geolocation rules for French Guiana:
    * `region` = `South America`
    * `country` = `French Guiana (France)`
    * `division` = `French Guiana (France)`
* Adding latitude and longitude coordinates for French Guiana, and using these when exporting the Auspice JSON

Note that changing the country name to `French Guiana` rather than `French Guiana (France)` would cause a [CyclicGeolocationRulesError](https://github.com/nextstrain/augur/blob/master/augur/curate/apply_geolocation_rules.py#L167-L170) as described [here](https://github.com/nextstrain/augur/issues/1648#issuecomment-2581432848).

Closes #21

## Related issue(s)

https://github.com/nextstrain/rabies/issues/21
https://github.com/nextstrain/augur/issues/1648

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
