### PR TITLE
Add frequencies panel

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -18,7 +18,7 @@ rule all:
     input:
         # Fill in path(s) to the final exported Auspice JSON(s)
         auspice_json="auspice/rabies.json",
-
+        tip_frequencies_json="auspice/rabies_tip-frequencies.json",
 
 # These rules are imported in the order that they are expected to run.
 # Each Snakefile will have documented inputs and outputs that should be kept as

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -66,6 +66,12 @@
     "country",
     "author"
   ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
   "metadata_columns": [
     "author",
     "strain",

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -14,3 +14,8 @@ filter:
     min_length: 5000
 ancestral:
     inference: "joint"
+tip_frequencies:
+    min_date: "2000-01-01"
+    max_date: "6M"
+    narrow_bandwidth: 0.2
+    wide_bandwidth: 0.6

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -42,3 +42,32 @@ rule export:
             --description {input.description} \
             2>&1 | tee {log}
         """
+
+rule tip_frequencies:
+    """
+    Estimating KDE frequencies for tips
+    """
+    input:
+        tree = "results/tree.nwk",
+        metadata = "data/metadata.tsv"
+    params:
+        strain_id = config["strain_id_field"],
+        min_date = config["tip_frequencies"]["min_date"],
+        max_date = config["tip_frequencies"]["max_date"],
+        narrow_bandwidth = config["tip_frequencies"]["narrow_bandwidth"],
+        wide_bandwidth = config["tip_frequencies"]["wide_bandwidth"]
+    output:
+        tip_freq = "auspice/rabies_tip-frequencies.json"
+    shell:
+        r"""
+        augur frequencies \
+            --method kde \
+            --tree {input.tree} \
+            --metadata {input.metadata} \
+            --metadata-id-columns {params.strain_id} \
+            --min-date {params.min_date} \
+            --max-date {params.max_date} \
+            --narrow-bandwidth {params.narrow_bandwidth} \
+            --wide-bandwidth {params.wide_bandwidth} \
+            --output {output.tip_freq}
+        """


### PR DESCRIPTION
## Description of proposed changes

Adds a frequencies panel.

Example tree is staged [here](https://nextstrain.org/staging/rabies/freqpanel).

The year 2000 was chosen as the start date for the frequencies panel based on visual inspection of a histogram of the number of sequences available on GenBank that meet our length criteria (greater than 5000bp) over time:

<img width="578" alt="image" src="https://github.com/user-attachments/assets/903d8e24-ca11-43a1-badb-9cfbfe1e4ea4" />



This PR currently keeps "Host" as the default coloring, since host species is an important aspect of rabies biology. However, it might be better to change the default coloring to "clade" so that the clades show up by default in the frequencies panel.

## Related issue(s)

Closes #23

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
